### PR TITLE
Make formatter compatible with Rspec >= 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ Or install it yourself as:
 
     $ gem install rspec-rainbow
 
-Then, when running rspec:
+Then running rspec >= 3.1:
+
+    $ rspec --format RainbowFormatter
+
+If you are running rspec < 3.1:
 
     $ rspec --format Rainbow
 
 If you want to use Rainbow by default, add it to your ```.rspec``` file.
 
-    --format Rainbow
+    --format RainbowFormatter
+
+Use `Rainbow` for Rspec < 3.1
 
 ## Contributing
 

--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -1,5 +1,6 @@
 require 'rspec/core/formatters/progress_formatter'
 
+# For Rspec >= 2.11, < 3.1
 class Rainbow < ::RSpec::Core::Formatters::ProgressFormatter
   PI_3 = Math::PI / 3
 

--- a/lib/rainbow_formatter.rb
+++ b/lib/rainbow_formatter.rb
@@ -1,0 +1,53 @@
+require 'rspec/core/formatters/base_text_formatter'
+
+# For Rspec >= 3.1
+class RainbowFormatter < ::RSpec::Core::Formatters::BaseTextFormatter
+
+  PI_3 = Math::PI / 3
+
+  ::RSpec::Core::Formatters.register self, :example_passed, :example_pending, :example_failed, :start_dump
+
+  def initialize(output)
+    # colors calculation stolen from Minitest's Pride Plugin
+    # https://github.com/seattlerb/minitest
+    @colors = (0...(6 * 7)).map { |n|
+      n *= 1.0 / 6
+      r  = (3 * Math.sin(n           ) + 3).to_i
+      g  = (3 * Math.sin(n + 2 * PI_3) + 3).to_i
+      b  = (3 * Math.sin(n + 4 * PI_3) + 3).to_i
+
+      color_index = 36 * r + 6 * g + b + 16
+      rainbow_color_code(color_index)
+    }
+    @color_index = 0
+
+    super
+  end
+
+  def example_passed(_notification)
+    @color_index == (@colors.size - 1) ? @color_index = 0 : @color_index += 1
+    output.print colorize('.', @colors[@color_index])
+  end
+
+  def example_pending(_notification)
+    output.print ::RSpec::Core::Formatters::ConsoleCodes.wrap('*', :pending)
+  end
+
+  def example_failed(_notification)
+    output.print ::RSpec::Core::Formatters::ConsoleCodes.wrap('F', :failure)
+  end
+
+  def start_dump(_notification)
+    output.puts
+  end
+
+  private
+
+  def rainbow_color_code(color_index)
+    "38;5;#{color_index}"
+  end
+
+  def colorize(str, color_code)
+    "\e[#{color_code}m#{str}\e[0m"
+  end
+end

--- a/rspec-rainbow.gemspec
+++ b/rspec-rainbow.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rspec-rainbow"
-  spec.version       = "0.1.0"
+  spec.version       = "0.2.0"
   spec.authors       = ["Mike Coutermarsh"]
   spec.email         = ["coutermarsh.mike@gmail.com"]
   spec.description   = %q{the rainbow progress formatter for RSpec}
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rspec', ['>= 2.14.0', '< 3.1.0']
+  spec.add_dependency 'rspec'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'rake', '~> 0'
 end


### PR DESCRIPTION
I added the class `RainbowFormatter` compatible with Rspec > 3.1

I left  `Rainbow` class in place for support of older versions of Rspec.